### PR TITLE
Additional documentation for the llnode plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | wip: [core dumps](core-dumps.md) |
 | wip: [tracking (de)optimizations](optimizations.md) |
 | tbd: [heap dumps](tbd.md) |
+| tbd: [native debuggers (gdb and lldb)](tbd.md) |
 | **External links** |
 | [read this to really understand how asynchronous code runs](https://nodejs.org/en/docs/guides/event-loop-timers-and-nexttick/) |
 

--- a/core-dumps.md
+++ b/core-dumps.md
@@ -18,8 +18,9 @@ If you didn't encounter a core dump before, it's probably because the operating 
   - set `--abort-on-uncaught-exception` to dump core on crash
   - call `process.abort()`
 - get the `core` file
-- segment it with a script from llnode `./llnode/scripts/readelf2segments.py ./core > core.ranges`
-- let lldb know where to look `export LLNODE_RANGESFILE=core.ranges`
+- if you are using lldb version 3.8 (not needed if you are using lldb version 3.9 or later):
+  - segment it with a script from llnode `./llnode/scripts/readelf2segments.py ./core > core.ranges`
+  - let lldb know where to look `export LLNODE_RANGESFILE=core.ranges`
 - run `lldb -c core`
 - use `v8` commands to analyze
 

--- a/llnode.md
+++ b/llnode.md
@@ -35,23 +35,26 @@ Note that lldb supports the use of a system plugin directory (`/usr/lib/lldb/plu
 
 | Task                                     | Command                                                                              |
 |------------------------------------------|--------------------------------------------------------------------------------------|
-| Display the JavaScript/C++ stack trace   | v8 bt [ &lt;number of frames &gt;]                                                   |
+| Display the help                         | v8 help                                                                              |
+| Display the JavaScript and C++ stack     | v8 bt [&lt;number of frames &gt;]                                                    |
 |                                          | output includes source file, line number, object addresses                           |
 |                                          | display source code using ‘frame select  &lt;frame number&gt;’ then ‘v8 source list’ |
 | List objects in the JavaScript heap      | v8 findjsobjects                                                                     |
 |                                          | provides number of objects, total size and type name                                 |
-| Display a JavaScript object              | v8 print  &lt;object address&gt; or v8 inspect  &lt;object address&gt;               |
+| Display a JavaScript object              | v8 print  &lt;object address&gt; or v8 inspect [-m -s -F] &lt;object address&gt;     |
 |                                          | provides constructor name, property names and values                                 |
-|                                          | -m option provides the map address                                                   |
-|                                          | –full-string and –string-length output options                                       |
-| Find JavaScript objects by type name     | v8 findjsinstances  &lt;type name&gt;                                                |
-|                                          | -m option provides the map address                                                   |
-|                                          | –full-string and –string-length output options                                       |
-| Find JavaScript objects by property name | v8 findrefs -n  &lt;property name&gt;                                                |
-| Find references to a JavaScript object   | v8 findrefs  &lt;object address&gt;                                                  |
+|                                          | -m option prints the object's map address                                            |
+|                                          | -s option prints source code for function objects                                    |
+|                                          | –F prints full string values without truncation                                      |
+| Find JavaScript objects by type name     | v8 findjsinstances [-m -s -F] &lt;type name&gt;                                      |
+|                                          | same output options as the ‘v8 inspect’ command                                      |
 | Display the constructor for an object    | v8 inspect  &lt;object address&gt;                                                   |
 | Display JavaScript source code           | v8 inspect -s  &lt;function address&gt;                                              |
 |                                          | or use ‘v8 source list’ for current stackframe, see ‘v8 bt’ above                    |
-| Display address of buffer memory         | v8 inspect  &lt;buffer object address&gt;                                            |
-| Display summary Node.js information      | v8 nodeinfo                                                                          |
+| Find JavaScript objects by reference     | v8 findrefs [-v -n -s] &lt;object address&gt; or &lt;name&gt; or &lt;string&gt;      |
+|                                          | -v option (default) finds objects that reference a specified object                  |
+|                                          | -n option finds objects that reference a specified property name                     |
+|                                          | -s option finds objects that reference a specified string                            |
+| Display raw address of buffer memory     | v8 inspect &lt;buffer object address&gt;                                             |
+| Display Node.js information summary      | v8 nodeinfo                                                                          |
 

--- a/llnode.md
+++ b/llnode.md
@@ -33,25 +33,27 @@ You'll need to install lldb too.
 
 ## llnode commands
 
-| Display the JavaScript/C++ stack trace   | v8 bt [<number of frames>]
-|                                          | default output includes source file, line number, object addresses
-|                                          | source code can be displayed using ‘frame select <frame number>’
-|                                          | followed by ‘v8 source list’
-| List objects in the JavaScript heap      | v8 findjsobjects
-|                                          | listed by object type name*
-|                                          | provides number of objects, total size and type name
-| Display a JavaScript object              | v8 print <object address>
-|                                          | v8 inspect <object address>
-|                                          | provides constructor name, property names and values
-|                                          | -m option provides the map address
-|                                          | –full-string and –string-length output options
-| Find JavaScript objects by type name     | v8 findjsinstances <type name>
-|                                          | -m option provides the map address
-|                                          | –full-string and –string-length output options
-| Find JavaScript objects by property name | v8 findrefs -n <property name>
-| Find references to a JavaScript object   | v8 findrefs <object address>
-| Display the constructor for an object    | v8 inspect <object address>
-| Display JavaScript source code           | v8 inspect -s <function address>, or
-|                                          | v8 source list for current stackframe, see ‘v8 bt’ above
-| Display address of buffer memory         | v8 inspect <buffer object address>
-| Display summary Node.js information      | v8 nodeinfo
+| Task                                     | Command                                                            |
+|------------------------------------------|--------------------------------------------------------------------|
+| Display the JavaScript/C++ stack trace   | v8 bt [<number of frames>]                                         |
+|                                          | output includes source file, line number, object addresses         |
+|                                          | source code can be displayed using ‘frame select <frame number>’   |
+|                                          | followed by ‘v8 source list’                                       |
+| List objects in the JavaScript heap      | v8 findjsobjects                                                   |
+|                                          | provides number of objects, total size and type name               |
+| Display a JavaScript object              | v8 print <object address>                                          |
+|                                          | v8 inspect <object address>                                        |
+|                                          | provides constructor name, property names and values               |
+|                                          | -m option provides the map address                                 |
+|                                          | –full-string and –string-length output options                     |
+| Find JavaScript objects by type name     | v8 findjsinstances <type name>                                     |
+|                                          | -m option provides the map address                                 |
+|                                          | –full-string and –string-length output options                     |
+| Find JavaScript objects by property name | v8 findrefs -n <property name>                                     |
+| Find references to a JavaScript object   | v8 findrefs <object address>                                       |
+| Display the constructor for an object    | v8 inspect <object address>                                        |
+| Display JavaScript source code           | v8 inspect -s <function address>, or                               |
+|                                          | v8 source list for current stackframe, see ‘v8 bt’ above           |
+| Display address of buffer memory         | v8 inspect <buffer object address>                                 |
+| Display summary Node.js information      | v8 nodeinfo                                                        |
+

--- a/llnode.md
+++ b/llnode.md
@@ -14,18 +14,18 @@ It's great that lldb+llnode can be used to read diagnostics from node, it used t
 
 ## Notes on installation
 
+First install lldb using apt-get, then install the llnode plugin from npm or from github:
+
 [https://npmjs.org/package/llnode](https://www.npmjs.org/package/llnode)
 
 or
 [https://github.com/nodejs/llnode](https://github.com/nodejs/llnode)
 
-Install using `npm install llnode` or follow the build instructions in the github project.
+TO install the plugin use `npm install llnode` or follow the build instructions in the github project.
 
 Note that lldb supports the use of a system plugin directory (`/usr/lib/lldb/plugins` on Linux). By installing a plugin in the system plugin directory you avoid having to run the lldb `plugin load llnode.so` command in each lldb session. The npm install does not add the llnode plugin to the system plugin directory. You can either copy the plugin: `sudo cp llnode.so /usr/lib/lldb/plugins` or if you are building from the github repository, install it using the `sudo make install-linux` build step. 
  
 *A global npm install of llnode, i.e. `npm install -g llnode`, does not work right now. Maybe we should raise an issue on llnode to have the -g install do the copy to the system plugin directory. It would need to run as sudo/root.*
-
-You'll need to install lldb too.
 
 *It should work on all flavors of ubuntu and most other distros with any version of lldb starting at 3.8. If you find out more, feel free to PR here*
 
@@ -33,27 +33,25 @@ You'll need to install lldb too.
 
 ## llnode commands
 
-| Task                                     | Command                                                            |
-|------------------------------------------|--------------------------------------------------------------------|
-| Display the JavaScript/C++ stack trace   | v8 bt [<number of frames>]                                         |
-|                                          | output includes source file, line number, object addresses         |
-|                                          | source code can be displayed using ‘frame select <frame number>’   |
-|                                          | followed by ‘v8 source list’                                       |
-| List objects in the JavaScript heap      | v8 findjsobjects                                                   |
-|                                          | provides number of objects, total size and type name               |
-| Display a JavaScript object              | v8 print <object address>                                          |
-|                                          | v8 inspect <object address>                                        |
-|                                          | provides constructor name, property names and values               |
-|                                          | -m option provides the map address                                 |
-|                                          | –full-string and –string-length output options                     |
-| Find JavaScript objects by type name     | v8 findjsinstances <type name>                                     |
-|                                          | -m option provides the map address                                 |
-|                                          | –full-string and –string-length output options                     |
-| Find JavaScript objects by property name | v8 findrefs -n <property name>                                     |
-| Find references to a JavaScript object   | v8 findrefs <object address>                                       |
-| Display the constructor for an object    | v8 inspect <object address>                                        |
-| Display JavaScript source code           | v8 inspect -s <function address>, or                               |
-|                                          | v8 source list for current stackframe, see ‘v8 bt’ above           |
-| Display address of buffer memory         | v8 inspect <buffer object address>                                 |
-| Display summary Node.js information      | v8 nodeinfo                                                        |
+| Task                                     | Command                                                                              |
+|------------------------------------------|--------------------------------------------------------------------------------------|
+| Display the JavaScript/C++ stack trace   | v8 bt [ &lt;number of frames &gt;]                                                   |
+|                                          | output includes source file, line number, object addresses                           |
+|                                          | display source code using ‘frame select  &lt;frame number&gt;’ then ‘v8 source list’ |
+| List objects in the JavaScript heap      | v8 findjsobjects                                                                     |
+|                                          | provides number of objects, total size and type name                                 |
+| Display a JavaScript object              | v8 print  &lt;object address&gt; or v8 inspect  &lt;object address&gt;               |
+|                                          | provides constructor name, property names and values                                 |
+|                                          | -m option provides the map address                                                   |
+|                                          | –full-string and –string-length output options                                       |
+| Find JavaScript objects by type name     | v8 findjsinstances  &lt;type name&gt;                                                |
+|                                          | -m option provides the map address                                                   |
+|                                          | –full-string and –string-length output options                                       |
+| Find JavaScript objects by property name | v8 findrefs -n  &lt;property name&gt;                                                |
+| Find references to a JavaScript object   | v8 findrefs  &lt;object address&gt;                                                  |
+| Display the constructor for an object    | v8 inspect  &lt;object address&gt;                                                   |
+| Display JavaScript source code           | v8 inspect -s  &lt;function address&gt;                                              |
+|                                          | or use ‘v8 source list’ for current stackframe, see ‘v8 bt’ above                    |
+| Display address of buffer memory         | v8 inspect  &lt;buffer object address&gt;                                            |
+| Display summary Node.js information      | v8 nodeinfo                                                                          |
 

--- a/llnode.md
+++ b/llnode.md
@@ -14,15 +14,44 @@ It's great that lldb+llnode can be used to read diagnostics from node, it used t
 
 ## Notes on installation
 
+[https://npmjs.org/package/llnode](https://www.npmjs.org/package/llnode)
+
+or
 [https://github.com/nodejs/llnode](https://github.com/nodejs/llnode)
 
-Use install instructions, `npm install -g llnode` doesn't seem to work yet.
-But I had no trouble building according to instructions.
+Install using `npm install llnode` or follow the build instructions in the github project.
+
+Note that lldb supports the use of a system plugin directory (`/usr/lib/lldb/plugins` on Linux). By installing a plugin in the system plugin directory you avoid having to run the lldb `plugin load llnode.so` command in each lldb session. The npm install does not add the llnode plugin to the system plugin directory. You can either copy the plugin: `sudo cp llnode.so /usr/lib/lldb/plugins` or if you are building from the github repository, install it using the `sudo make install-linux` build step. 
+ 
+*A global npm install of llnode, i.e. `npm install -g llnode`, does not work right now. Maybe we should raise an issue on llnode to have the -g install do the copy to the system plugin directory. It would need to run as sudo/root.*
 
 You'll need to install lldb too.
-
-
 
 *It should work on all flavors of ubuntu and most other distros with any version of lldb starting at 3.8. If you find out more, feel free to PR here*
 
 *On 2017-02-03 I managed to install lldb-3.8 with latest llnode in xubuntu 16.04.1 kernel 4.4.0-62-generic x86_64*
+
+## llnode commands
+
+| Display the JavaScript/C++ stack trace   | v8 bt [<number of frames>]
+|                                          | default output includes source file, line number, object addresses
+|                                          | source code can be displayed using ‘frame select <frame number>’
+|                                          | followed by ‘v8 source list’
+| List objects in the JavaScript heap      | v8 findjsobjects
+|                                          | listed by object type name*
+|                                          | provides number of objects, total size and type name
+| Display a JavaScript object              | v8 print <object address>
+|                                          | v8 inspect <object address>
+|                                          | provides constructor name, property names and values
+|                                          | -m option provides the map address
+|                                          | –full-string and –string-length output options
+| Find JavaScript objects by type name     | v8 findjsinstances <type name>
+|                                          | -m option provides the map address
+|                                          | –full-string and –string-length output options
+| Find JavaScript objects by property name | v8 findrefs -n <property name>
+| Find references to a JavaScript object   | v8 findrefs <object address>
+| Display the constructor for an object    | v8 inspect <object address>
+| Display JavaScript source code           | v8 inspect -s <function address>, or
+|                                          | v8 source list for current stackframe, see ‘v8 bt’ above
+| Display address of buffer memory         | v8 inspect <buffer object address>
+| Display summary Node.js information      | v8 nodeinfo


### PR DESCRIPTION
This is mostly extra information about installing and using the llnode plugin for lldb, including a list of available commands.

The placeholder for gdb and lldb native debugging is to cover this recently discovered v8 tooling:
https://github.com/nodejs/node/pull/12061#issuecomment-290659521

The core dump update is just to document that with lldb 3.9 and later you don't need to run the address ranges script